### PR TITLE
[base-api-schemas] script to generate the full schema used by the portal

### DIFF
--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -106,7 +106,9 @@ var TypeScript, _, traverse; // from global scope
                 requirementAnnotations: ["_hiddenFor", "_visibleFor"],
                 emptyAnnotations: ["_hiddenByDefault"],
                 useDescription: true,
-                requiredAnnotation: "_leanRequired"
+                requiredAnnotation: "_leanRequired",
+                ignoreNumbersInRequirementAnnotations: true,
+                strictHideAnnotation: "_leanHidden"
             };
         }
         if (type === "api") {
@@ -116,7 +118,8 @@ var TypeScript, _, traverse; // from global scope
                 requirementAnnotations: ["_hiddenFor", "_visibleFor"],
                 emptyAnnotations: ["_hiddenByDefault"],
                 useDescription: false,
-                requiredAnnotation: "_leanRequired"
+                requiredAnnotation: "_leanRequired",
+                ignoreNumbersInRequirementAnnotations: true,
             };
         }
         return {
@@ -125,6 +128,8 @@ var TypeScript, _, traverse; // from global scope
             requirementAnnotations: ["_requiredFor", "_optionalFor", "_hiddenFor", "_visibleFor"],
             emptyAnnotations: ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"],
             useDescription: true,
+            requiredAnnotation: null,
+            ignoreNumbersInRequirementAnnotations: false,
         };
     }
 
@@ -372,7 +377,19 @@ var TypeScript, _, traverse; // from global scope
                 continue;
             }
             if (schemaTypeDefaults.requirementAnnotations.indexOf(keyword) !== -1) {
-                to[keyword] = annotationTokens[1].split(",");
+                var splittedTokens = annotationTokens[1].split(",");
+
+                if (schemaTypeDefaults.ignoreNumbersInRequirementAnnotations) {
+                    /*jshint loopfunc:true */
+                    var filteredTokens = _.filter(splittedTokens, function(str) {
+                        return !str.startsWith("#");
+                    });
+                    if (filteredTokens.length !== 0) {
+                        to[keyword] = filteredTokens;
+                    }
+                } else {
+                    to[keyword] = splittedTokens;
+                }
                 continue;
             }
             if (schemaTypeDefaults.emptyAnnotations.indexOf(keyword) !== -1) {

--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -39,7 +39,7 @@ var TypeScript, _, traverse; // from global scope
 
     var schemaTypeToOptions = {
         portal: {
-            defaultProperties: { additionalProperties: true},
+            defaultProperties: { additionalProperties: true },
             annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
             requirementAnnotations: ["_hiddenFor", "_visibleFor"],
             emptyAnnotations: ["_hiddenByDefault"],
@@ -49,7 +49,7 @@ var TypeScript, _, traverse; // from global scope
             strictHideAnnotation: "_leanHidden"
         },
         api: {
-            defaultProperties: { additionalProperties: true},
+            defaultProperties: { additionalProperties: true },
             annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
             requirementAnnotations: ["_hiddenFor", "_visibleFor"],
             emptyAnnotations: ["_hiddenByDefault"],
@@ -60,7 +60,7 @@ var TypeScript, _, traverse; // from global scope
         }
     };
     var defaultOptions = {
-        defaultProperties: { additionalProperties: false},
+        defaultProperties: { additionalProperties: false },
         annotedValidationKeywordPattern: /@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|@default|@maxLength)/gi,
         requirementAnnotations: ["_requiredFor", "_optionalFor", "_hiddenFor", "_visibleFor"],
         emptyAnnotations: ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"],

--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -34,18 +34,24 @@ var TypeScript, _, traverse; // from global scope
     var api = {};
     var primitiveTypes = [ "string", "number", "boolean", "any", "integer" ];
     var validationKeywords = [ "type", "minimum", "exclusiveMinimum", "maximum", "exclusiveMaximum", "multipleOf", "minLength", "maxLength", "format", "pattern", "minItems", "maxItems", "uniqueItems", "default", "additionalProperties" ];
-    var annotedValidationKeywordPattern = /@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|@default|@maxLength)/gi;
-    //var annotedValidationKeywordPattern = /@_?[a-z.]+\s*[^@\s]+/gi;
+
     var TypescriptASTFlags = { "optionalName" : 4, "arrayType" : 8 };
+
     var defaultProperties = { additionalProperties: false};
+    var annotedValidationKeywordPattern = /@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|@default|@maxLength)/gi;
+
+    var REQUIREMENT_ANNOTATIONS = ["_requiredFor", "_optionalFor", "_hiddenFor", "_visibleFor"];
+    var EMPTY_ANNOTATIONS = ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"];
 
     /**
      * Creates json-schema type definitions from a type script.
      *
      * @param script {string} URI pointing to the source type script or the script itself.
      * @param refPath {string} A path to prepend to $ref references.
+     * @param schemaType {'portal'|'api'|undefined} sets the type of schema to generate
      */
-    api.definitions = function (script, refPath) {
+    api.definitions = function (script, refPath, schemaType) {
+        var schemaTypeDefaults = getConstsBySchemaType(schemaType);
         return Q.promise(function (resolve) {
             typson.tree(script).done(function (tree) {
                 TypeScript = typson.TypeScript;
@@ -55,7 +61,7 @@ var TypeScript, _, traverse; // from global scope
                     };
                 _.each(tree, function (script) {
                     _.each(script.moduleElements.members, function (decl) {
-                        handleDeclaration(decl, definitions, refPath, "");
+                        handleDeclaration(decl, definitions, refPath, "", schemaTypeDefaults);
                     });
                 });
 
@@ -80,10 +86,11 @@ var TypeScript, _, traverse; // from global scope
      * @param script {string} URI pointing to the source type script or the script itself.
      * @param type {string} The type to generate the schema from.
      * @param [id] {string} Schema id.
+     * @param schemaType {'portal'|'api'|undefined} sets the type of schema to generate
      */
-    api.schema = function (script, type, id) {
+    api.schema = function (script, type, id, schemaType) {
         return Q.promise(function (resolve) {
-            api.definitions(script, "#/definitions").done(function(definitions) {
+            api.definitions(script, "#/definitions", schemaType).done(function(definitions) {
                 var schema = {};
                 schema.$schema = "http://json-schema.org/draft-04/schema#";
                 _.extend(schema, definitions[type]);
@@ -97,10 +104,35 @@ var TypeScript, _, traverse; // from global scope
         });
     };
 
-    function handleDeclaration(decl, definitions, refPath, modulePath) {
+    function getConstsBySchemaType(type) {
+        if (type === "portal") {
+            return {
+                defaultProperties: { additionalProperties: true},
+                annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
+                requirementAnnotations: ["_hiddenFor", "_visibleFor"],
+                emptyAnnotations: ["_hiddenByDefault"]
+            };
+        }
+        if (type === "api") {
+            return {
+                defaultProperties: { additionalProperties: true},
+                annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
+                requirementAnnotations: ["_hiddenFor", "_visibleFor"],
+                emptyAnnotations: ["_hiddenByDefault"]
+            };
+        }
+        return {
+            defaultProperties: { additionalProperties: false},
+            annotedValidationKeywordPattern: /@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|@default|@maxLength)/gi,
+            requirementAnnotations: ["_requiredFor", "_optionalFor", "_hiddenFor", "_visibleFor"],
+            emptyAnnotations: ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"]
+        };
+    }
+
+    function handleDeclaration(decl, definitions, refPath, modulePath, schemaTypeDefaults) {
         if (decl.nodeType() === TypeScript.NodeType.InterfaceDeclaration ||
                 decl.nodeType() === TypeScript.NodeType.ClassDeclaration) {
-            handleInterfaceDeclaration(decl, definitions, refPath, modulePath);
+            handleInterfaceDeclaration(decl, definitions, refPath, modulePath, schemaTypeDefaults);
         }
         else if (decl.nodeType() === TypeScript.NodeType.ModuleDeclaration) {
             if (decl.getModuleFlags() & TypeScript.ModuleFlags.IsEnum) {
@@ -111,7 +143,7 @@ var TypeScript, _, traverse; // from global scope
                     if(!(decl.getModuleFlags() & TypeScript.ModuleFlags.IsWholeFile)) {
                         subModulePath+=(decl.name.actualText+".");
                     }
-                    handleDeclaration(subDecl, definitions, refPath, subModulePath);
+                    handleDeclaration(subDecl, definitions, refPath, subModulePath, schemaTypeDefaults);
                 });
             }
         }
@@ -123,17 +155,17 @@ var TypeScript, _, traverse; // from global scope
      * @param type {object} the TypeScript AST node associated to the interface declaration
      * @param definitions {object} the set of handled interface and enum definitions
      */
-    function handleInterfaceDeclaration(type, definitions, refPath, modulePath) {
+    function handleInterfaceDeclaration(type, definitions, refPath, modulePath, schemaTypeDefaults) {
         var name = (modulePath.length > 0 ? modulePath : "") + type.name.actualText;
         var definition = definitions.interfaces[name] = {};
         definition.id = name;
         definition.type = "object";
-        copyComment(type, definition);
+        copyComment(type, definition, schemaTypeDefaults);
 
         definition.properties = {};
         mergeInheritedProperties(type, definition, definitions);
-        handlePropertyDeclaration(type, definition, definitions, refPath);
-        _.defaults(definition, defaultProperties);
+        handlePropertyDeclaration(type, definition, definitions, refPath, schemaTypeDefaults);
+        _.defaults(definition, schemaTypeDefaults.defaultProperties);
     }
 
 
@@ -146,10 +178,10 @@ var TypeScript, _, traverse; // from global scope
      * @param definition {object} the property definition
      * @param definitions {object} the set of handled interface and enum definitions
      */
-    function handlePropertyDeclaration(type, definition, definitions, refPath) {
+    function handlePropertyDeclaration(type, definition, definitions, refPath, schemaTypeDefaults) {
         _.each(type.members.members, function (variable) {
             var property = definition.properties[variable.id.actualText] = {};
-            copyComment(variable, property);
+            copyComment(variable, property, schemaTypeDefaults);
             var overridenType = property.type;
             var variableType = extractFullTypeName(variable.typeExpr.term);
             var propertyType = null;
@@ -179,19 +211,19 @@ var TypeScript, _, traverse; // from global scope
 
                     if (!variableType) {
                         // Map where value is an inline property declaration
-                        _.defaults(property, defaultProperties);
-                        _.defaults(property.additionalProperties, defaultProperties);
+                        _.defaults(property, schemaTypeDefaults.defaultProperties);
+                        _.defaults(property.additionalProperties, schemaTypeDefaults.defaultProperties);
                         property.additionalProperties.type = "object";
                         property.additionalProperties.properties = {};
-                        handlePropertyDeclaration(variable.typeExpr.term.members.members[0].returnTypeAnnotation.term, property.additionalProperties, definitions);
+                        handlePropertyDeclaration(variable.typeExpr.term.members.members[0].returnTypeAnnotation.term, property.additionalProperties, definitions, undefined, schemaTypeDefaults);
                         variableType = "any";
                     }
                 }
                 // Object (inline declaration)
                 else {
-                    _.defaults(property, defaultProperties);
+                    _.defaults(property, schemaTypeDefaults.defaultProperties);
                     property.properties = {};
-                    handlePropertyDeclaration(variable.typeExpr.term, property, definitions);
+                    handlePropertyDeclaration(variable.typeExpr.term, property, definitions, undefined, schemaTypeDefaults);
                     variableType = "any";
                 }
             }
@@ -220,7 +252,6 @@ var TypeScript, _, traverse; // from global scope
     }
 
     function extractFullTypeName(term) {
-
         if(term.actualText) {
             return term.actualText;
         } else {
@@ -289,11 +320,11 @@ var TypeScript, _, traverse; // from global scope
      * @param from {object} the TypeScript AST node
      * @param to {object} the destination variable or definition.
      */
-    function copyComment(from, to) {
+    function copyComment(from, to, schemaTypeDefaults) {
         var comments = from.docComments();
         if (comments.length > 0) {
             var commentContent = comments.slice(-1)[0].getDocCommentTextValue();
-            copyValidationKeywords(copyDescription(commentContent, to), to);
+            copyValidationKeywords(copyDescription(commentContent, to), to, schemaTypeDefaults);
         }
     }
 
@@ -315,8 +346,6 @@ var TypeScript, _, traverse; // from global scope
         return delimiterIndex < 0 ? "" : comment.slice(delimiterIndex);
     }
 
-    var REQUIREMENT_ANNOTATIONS = ["_requiredFor", "_optionalFor", "_hiddenFor", "_visibleFor"];
-    var EMPTY_ANNOTATIONS = ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"];
     /**
      * Extracts the schema validation keywords stored in a comment and register them as properties.
      * A validation keyword starts by a @. It has a name and a value. Several keywords may occur.
@@ -324,11 +353,11 @@ var TypeScript, _, traverse; // from global scope
      * @param comment {string} the full comment.
      * @param to {object} the destination variable.
      */
-    function copyValidationKeywords(comment, to) {
-        annotedValidationKeywordPattern.lastIndex = 0;
+    function copyValidationKeywords(comment, to, schemaTypeDefaults) {
+        schemaTypeDefaults.annotedValidationKeywordPattern.lastIndex = 0;
         // TODO: to improve the use of the exec method: it could make the tokenization
         var annotation;
-        while ((annotation = annotedValidationKeywordPattern.exec(comment))) {
+        while ((annotation = schemaTypeDefaults.annotedValidationKeywordPattern.exec(comment))) {
             var annotationTokens = annotation[0].split(" ");
             var keyword = annotationTokens[0].slice(1);
             var path = keyword.split(".");
@@ -337,11 +366,11 @@ var TypeScript, _, traverse; // from global scope
                 context = path[0];
                 keyword = path[1];
             }
-            if (REQUIREMENT_ANNOTATIONS.indexOf(keyword) !== -1) {
+            if (schemaTypeDefaults.requirementAnnotations.indexOf(keyword) !== -1) {
                 to[keyword] = annotationTokens[1].split(",");
                 continue;
             }
-            if (EMPTY_ANNOTATIONS.indexOf(keyword) !== -1) {
+            if (schemaTypeDefaults.emptyAnnotations.indexOf(keyword) !== -1) {
                 to[keyword] = "";
                 continue;
             }

--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -37,12 +37,6 @@ var TypeScript, _, traverse; // from global scope
 
     var TypescriptASTFlags = { "optionalName" : 4, "arrayType" : 8 };
 
-    var defaultProperties = { additionalProperties: false};
-    var annotedValidationKeywordPattern = /@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|@default|@maxLength)/gi;
-
-    var REQUIREMENT_ANNOTATIONS = ["_requiredFor", "_optionalFor", "_hiddenFor", "_visibleFor"];
-    var EMPTY_ANNOTATIONS = ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"];
-
     /**
      * Creates json-schema type definitions from a type script.
      *
@@ -110,7 +104,8 @@ var TypeScript, _, traverse; // from global scope
                 defaultProperties: { additionalProperties: true},
                 annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
                 requirementAnnotations: ["_hiddenFor", "_visibleFor"],
-                emptyAnnotations: ["_hiddenByDefault"]
+                emptyAnnotations: ["_hiddenByDefault"],
+                useDescription: true,
             };
         }
         if (type === "api") {
@@ -118,14 +113,16 @@ var TypeScript, _, traverse; // from global scope
                 defaultProperties: { additionalProperties: true},
                 annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
                 requirementAnnotations: ["_hiddenFor", "_visibleFor"],
-                emptyAnnotations: ["_hiddenByDefault"]
+                emptyAnnotations: ["_hiddenByDefault"],
+                useDescription: false,
             };
         }
         return {
             defaultProperties: { additionalProperties: false},
             annotedValidationKeywordPattern: /@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|@default|@maxLength)/gi,
             requirementAnnotations: ["_requiredFor", "_optionalFor", "_hiddenFor", "_visibleFor"],
-            emptyAnnotations: ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"]
+            emptyAnnotations: ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"],
+            useDescription: true,
         };
     }
 
@@ -324,7 +321,7 @@ var TypeScript, _, traverse; // from global scope
         var comments = from.docComments();
         if (comments.length > 0) {
             var commentContent = comments.slice(-1)[0].getDocCommentTextValue();
-            copyValidationKeywords(copyDescription(commentContent, to), to, schemaTypeDefaults);
+            copyValidationKeywords(copyDescription(commentContent, to, schemaTypeDefaults), to, schemaTypeDefaults);
         }
     }
 
@@ -336,11 +333,11 @@ var TypeScript, _, traverse; // from global scope
      * @param to {object} the destination variable or definition.
      * @returns {string} the full comment minus the beginning description part.
      */
-    function copyDescription(comment, to) {
+    function copyDescription(comment, to, schemaTypeDefaults) {
         var delimiter = "@";
         var delimiterIndex = comment.indexOf(delimiter);
         var description = comment.slice(0, delimiterIndex < 0 ? comment.length : delimiterIndex);
-        if (description.length > 0) {
+        if (description.length > 0 && schemaTypeDefaults.useDescription) {
             to.description = description.replace(/\s+$/g, "");
         }
         return delimiterIndex < 0 ? "" : comment.slice(delimiterIndex);

--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -106,6 +106,7 @@ var TypeScript, _, traverse; // from global scope
                 requirementAnnotations: ["_hiddenFor", "_visibleFor"],
                 emptyAnnotations: ["_hiddenByDefault"],
                 useDescription: true,
+                requiredAnnotation: "_leanRequired"
             };
         }
         if (type === "api") {
@@ -115,6 +116,7 @@ var TypeScript, _, traverse; // from global scope
                 requirementAnnotations: ["_hiddenFor", "_visibleFor"],
                 emptyAnnotations: ["_hiddenByDefault"],
                 useDescription: false,
+                requiredAnnotation: "_leanRequired"
             };
         }
         return {
@@ -184,11 +186,13 @@ var TypeScript, _, traverse; // from global scope
             var propertyType = null;
 
             //required
-            if (!(variable.id.getFlags() & TypescriptASTFlags.optionalName)) {
-                if (!definition.required) {
-                    definition.required = [];
+            if (!schemaTypeDefaults.requiredAnnotation) {
+                if (!(variable.id.getFlags() & TypescriptASTFlags.optionalName)) {
+                    if (!definition.required) {
+                        definition.required = [];
+                    }
+                    definition.required.push(variable.id.actualText);
                 }
-                definition.required.push(variable.id.actualText);
             }
             //arrays
             if (variable.typeExpr.getFlags() & TypescriptASTFlags.arrayType) {
@@ -362,6 +366,10 @@ var TypeScript, _, traverse; // from global scope
             if (path.length > 1) {
                 context = path[0];
                 keyword = path[1];
+            }
+            if (schemaTypeDefaults.requiredAnnotation === keyword) {
+                to.required = annotationTokens[1].split(",");
+                continue;
             }
             if (schemaTypeDefaults.requirementAnnotations.indexOf(keyword) !== -1) {
                 to[keyword] = annotationTokens[1].split(",");

--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -37,6 +37,39 @@ var TypeScript, _, traverse; // from global scope
 
     var TypescriptASTFlags = { "optionalName" : 4, "arrayType" : 8 };
 
+    var schemaTypeToOptions = {
+        portal: {
+            defaultProperties: { additionalProperties: true},
+            annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
+            requirementAnnotations: ["_hiddenFor", "_visibleFor"],
+            emptyAnnotations: ["_hiddenByDefault"],
+            useDescription: true,
+            requiredAnnotation: "_leanRequired",
+            ignoreNumbersInRequirementAnnotations: true,
+            strictHideAnnotation: "_leanHidden"
+        },
+        api: {
+            defaultProperties: { additionalProperties: true},
+            annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
+            requirementAnnotations: ["_hiddenFor", "_visibleFor"],
+            emptyAnnotations: ["_hiddenByDefault"],
+            useDescription: false,
+            requiredAnnotation: "_leanRequired",
+            ignoreNumbersInRequirementAnnotations: true,
+            strictHideAnnotation: "_leanHidden"
+        }
+    };
+    var defaultOptions = {
+        defaultProperties: { additionalProperties: false},
+        annotedValidationKeywordPattern: /@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|@default|@maxLength)/gi,
+        requirementAnnotations: ["_requiredFor", "_optionalFor", "_hiddenFor", "_visibleFor"],
+        emptyAnnotations: ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"],
+        useDescription: true,
+        requiredAnnotation: null,
+        ignoreNumbersInRequirementAnnotations: false,
+        strictHideAnnotation: null
+    };
+
     /**
      * Creates json-schema type definitions from a type script.
      *
@@ -45,7 +78,7 @@ var TypeScript, _, traverse; // from global scope
      * @param schemaType {'portal'|'api'|undefined} sets the type of schema to generate
      */
     api.definitions = function (script, refPath, schemaType) {
-        var schemaTypeDefaults = getConstsBySchemaType(schemaType);
+        var schemaTypeDefaults = getOptionsBySchemaType(schemaType);
         return Q.promise(function (resolve) {
             typson.tree(script).done(function (tree) {
                 TypeScript = typson.TypeScript;
@@ -98,39 +131,8 @@ var TypeScript, _, traverse; // from global scope
         });
     };
 
-    function getConstsBySchemaType(type) {
-        if (type === "portal") {
-            return {
-                defaultProperties: { additionalProperties: true},
-                annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
-                requirementAnnotations: ["_hiddenFor", "_visibleFor"],
-                emptyAnnotations: ["_hiddenByDefault"],
-                useDescription: true,
-                requiredAnnotation: "_leanRequired",
-                ignoreNumbersInRequirementAnnotations: true,
-                strictHideAnnotation: "_leanHidden"
-            };
-        }
-        if (type === "api") {
-            return {
-                defaultProperties: { additionalProperties: true},
-                annotedValidationKeywordPattern: /@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_hiddenByDefault|@default|@maxLength)/gi,
-                requirementAnnotations: ["_hiddenFor", "_visibleFor"],
-                emptyAnnotations: ["_hiddenByDefault"],
-                useDescription: false,
-                requiredAnnotation: "_leanRequired",
-                ignoreNumbersInRequirementAnnotations: true,
-            };
-        }
-        return {
-            defaultProperties: { additionalProperties: false},
-            annotedValidationKeywordPattern: /@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|(@|@_)[a-z0-9A-Z\'\.]+\s.*|(@_useForExample|@_requiredIfAvailable|@_hiddenByDefault|@default|@maxLength)/gi,
-            requirementAnnotations: ["_requiredFor", "_optionalFor", "_hiddenFor", "_visibleFor"],
-            emptyAnnotations: ["_useForExample", "_requiredIfAvailable", "_hiddenByDefault"],
-            useDescription: true,
-            requiredAnnotation: null,
-            ignoreNumbersInRequirementAnnotations: false,
-        };
+    function getOptionsBySchemaType(type) {
+        return schemaTypeToOptions[type] || defaultOptions;
     }
 
     function handleDeclaration(decl, definitions, refPath, modulePath, schemaTypeDefaults) {
@@ -164,7 +166,8 @@ var TypeScript, _, traverse; // from global scope
         var definition = definitions.interfaces[name] = {};
         definition.id = name;
         definition.type = "object";
-        copyComment(type, definition, schemaTypeDefaults);
+        var commentContent = extractComment(type);
+        copyComment(commentContent, definition, schemaTypeDefaults);
 
         definition.properties = {};
         mergeInheritedProperties(type, definition, definitions);
@@ -184,8 +187,14 @@ var TypeScript, _, traverse; // from global scope
      */
     function handlePropertyDeclaration(type, definition, definitions, refPath, schemaTypeDefaults) {
         _.each(type.members.members, function (variable) {
+            var commentContent = extractComment(variable);
+            if (schemaTypeDefaults.strictHideAnnotation &&
+                (commentContent || "").indexOf(schemaTypeDefaults.strictHideAnnotation) !== -1) {
+                return;
+            }
+
             var property = definition.properties[variable.id.actualText] = {};
-            copyComment(variable, property, schemaTypeDefaults);
+            copyComment(commentContent, property, schemaTypeDefaults);
             var overridenType = property.type;
             var variableType = extractFullTypeName(variable.typeExpr.term);
             var propertyType = null;
@@ -305,6 +314,7 @@ var TypeScript, _, traverse; // from global scope
      *
      * @param type {object} the TypeScript AST node associated to the enum declaration
      * @param definitions {object} the set of handled interface and enum definitions
+     * @param modulePath
      */
     function handleEnumDeclaration(type, definitions, modulePath) {
         var name = (modulePath.length > 0 ? modulePath : "") + type.name.actualText;
@@ -320,18 +330,25 @@ var TypeScript, _, traverse; // from global scope
         });
     }
 
+    function extractComment(from) {
+        var comments = from.docComments();
+        if (comments.length > 0) {
+            return comments.slice(-1)[0].getDocCommentTextValue();
+        }
+    }
+
     /**
      * Extracts the description and the validation keywords from a comment
      *
-     * @param from {object} the TypeScript AST node
+     * @param commentContent
      * @param to {object} the destination variable or definition.
+     * @param schemaTypeDefaults
      */
-    function copyComment(from, to, schemaTypeDefaults) {
-        var comments = from.docComments();
-        if (comments.length > 0) {
-            var commentContent = comments.slice(-1)[0].getDocCommentTextValue();
-            copyValidationKeywords(copyDescription(commentContent, to, schemaTypeDefaults), to, schemaTypeDefaults);
+    function copyComment(commentContent, to, schemaTypeDefaults) {
+        if (!commentContent) {
+            return;
         }
+        copyValidationKeywords(copyDescription(commentContent, to, schemaTypeDefaults), to, schemaTypeDefaults);
     }
 
     /**

--- a/test/spec/bulk.test.js
+++ b/test/spec/bulk.test.js
@@ -21,10 +21,10 @@
         assert.ok(schema);
     });
 
-    function assertDefinitions(group, name, type) {
+    function assertDefinitions(group, name, type, schemaType) {
         it.eventually('"' + group + '"', function () {
 
-            return schema.definitions(baseDir + 'test/spec/' + group + '/' + name, type).then(function (actual) {
+            return schema.definitions(baseDir + 'test/spec/' + group + '/' + name, type, schemaType).then(function (actual) {
                 assert.isObject(actual, 'actual');
 
                 // lets save the actual result for later
@@ -40,10 +40,10 @@
         });
     }
 
-    function assertSchema(group, name, type) {
+    function assertSchema(group, name, type, schemaType) {
         it.eventually('"' + group + '"', function () {
 
-            return schema.schema(baseDir + 'test/spec/' + group + '/' + name, type).then(function (actual) {
+            return schema.schema(baseDir + 'test/spec/' + group + '/' + name, type, undefined, schemaType).then(function (actual) {
                 assert.isObject(actual, 'actual');
 
                 // lets save the actual result for later
@@ -66,6 +66,7 @@
         assertDefinitions('interface-multi', 'main.ts', 'MyObject');
 
         assertDefinitions('forter-classic', 'main.ts', 'Transaction');
+        assertDefinitions('forter-lean-portal', 'main.ts', 'Transaction', 'portal');
     });
 
     describe('schema', function () {
@@ -78,5 +79,6 @@
         assertSchema('module-interface-deep', 'main.ts', 'MyObject');
 
         assertSchema('forter-classic', 'main.ts', 'Transaction');
+        assertSchema('forter-lean-portal', 'main.ts', 'Transaction', 'portal');
     });
 });

--- a/test/spec/forter-classic/definitions.json
+++ b/test/spec/forter-classic/definitions.json
@@ -12,7 +12,10 @@
             },
             "orderType": {
                 "type": "string",
-                "_hiddenFor": ["3ds2only"]
+                "_hiddenFor": ["3ds2only"],
+                "metadata": {
+                    "hiddenForSynthetic": true
+                }
             },
             "authorizationStep": {
                 "type": "string",

--- a/test/spec/forter-classic/main.ts
+++ b/test/spec/forter-classic/main.ts
@@ -13,6 +13,7 @@ interface Transaction {
     orderId: string;
     /**
      * @_hiddenFor 3ds2only
+     * @metadata.hiddenForSynthetic true
      */
     orderType: string;
     /**

--- a/test/spec/forter-classic/schema.json
+++ b/test/spec/forter-classic/schema.json
@@ -12,7 +12,10 @@
         },
         "orderType": {
             "type": "string",
-            "_hiddenFor": ["3ds2only"]
+            "_hiddenFor": ["3ds2only"],
+            "metadata": {
+                "hiddenForSynthetic": true
+            }
         },
         "authorizationStep": {
             "type": "string",

--- a/test/spec/forter-lean-portal/main.ts
+++ b/test/spec/forter-lean-portal/main.ts
@@ -2,13 +2,13 @@
  * The request object containing information about the customer and order needed by Forter in order to provide a decision
  * @metadata.endpoint /v2/orders/:id
  * @metadata.method ["POST"]
+ * @_leanRequired orderId
  */
 interface Transaction {
     /**
      * Unique order/transaction identifier
      * @default 2356fdse0rr489
      * @maxLength 40
-     * @_leanRequired
      */
     orderId: string;
     /**

--- a/test/spec/forter-lean-portal/main.ts
+++ b/test/spec/forter-lean-portal/main.ts
@@ -30,6 +30,6 @@ interface Transaction {
      * hidden from schema
      * @_leanHidden
      */
-    iAhidden: string
+    iAmHidden: string
 
 }

--- a/test/spec/forter-lean-portal/main.ts
+++ b/test/spec/forter-lean-portal/main.ts
@@ -26,4 +26,10 @@ interface Transaction {
      * @_useForExample
      */
     accountOwner?: string
+    /**
+     * hidden from schema
+     * @_leanHidden
+     */
+    iAhidden: string
+
 }

--- a/test/spec/forter-lean-portal/schema.json
+++ b/test/spec/forter-lean-portal/schema.json
@@ -16,7 +16,6 @@
         "authorizationStep": {
             "type": "string",
             "_hiddenByDefault": "",
-            "_optionalFor": ["magento2"],
             "_visibleFor": ["preauth"]
         },
         "accountOwner": {


### PR DESCRIPTION
asana: https://app.asana.com/0/23095211578528/1202687600148556

**defaultProperties** - object which contains properties to be added to every object
**annotedValidationKeywordPattern** - regex to find relevant annotations in the comment
**requirementAnnotations** - list of non empty annotations (empty = no strings after) to use
**emptyAnnotations** - list of empty annotations
**useDescription** - boolean to specify if the description from the comment should be used
**requiredAnnotation** - string with a replacement to the typscript required system
**ignoreNumbersInRequirementAnnotations** - ignores the annotation values start with '#'
**strictHideAnnotation** - string with the annotation name to be used when hiding properties